### PR TITLE
New Files:  index and get-sakai

### DIFF
--- a/get-sakai.html
+++ b/get-sakai.html
@@ -1,0 +1,19 @@
+<html>
+<head>
+<title>Get Sakai</title>
+</head>
+<body>
+<h1>Get Sakai</h1>
+<p>
+Sakai is available in two distribution forms:  binary and source.  The binary distribution is a pre-packaged form of Saka that has everything you need to set up a demonstration verison of the Collaboration Learning Environment (CLE).  While it is a fully functioning Sakai, it is not recommended for production use.
+<p>
+If you'd like to start setting up Sakai for production use, the source distribution is recommended.  The installation instructions will tell you how to download the Sakai course files, build them, and configure the system for the database of your choice (MySQL or Oracle).
+</p>
+<h2>Sakai 2.9 Downloading and Installation Instructions</h2>
+Please refer to the following instructions:
+<ul>
+	<li><a href=https://confluence.sakaiproject.org/pages/viewpage.action?pageId=82249313>Binary Distribution</a></li>
+	<li><a href=https://confluence.sakaiproject.org/pages/viewpage.action?pageId=82249316>Source Distribution</a></li>
+</ul>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,19 @@
+<html>
+<head>
+<title>Master Index</title>
+</head>
+<body>
+<h1>Master Index</h1>
+This is the index of the root level files.  As the number of files gets bigger, sub-folders will be created to contained major topic areas.  Each folder should have it's own index.html file to provide navigation.  Files marked with an asterisk below denot files that have not been written yet.
+<ul>
+<li><a href=about-sakai.html>About Sakai</a></li>
+<li><a href=sakaiger.html>Sakai Mascot</a></li>
+<li><a href=get-sakai.html>Get Sakai *</a></li>
+    <ul>
+    <li><a href=get-demo.html>Get the Sakai Demo *</a</li>
+    <li><a href=get-source.html>Get Sakai From Sources *</a</li>
+    </ul>
+</li>
+</ul>
+</body>
+</html>


### PR DESCRIPTION
The index file serves as a table of contents of all files in this
directory, which is the root directory in this case.  Eventually, we
will have sub-directories and I recommend that we have an index file for
each of them.

I have also taken a crack at a "Get Sakai" file.  Currently, it links to
the installation instructions on Confluence for 2.9.  We should discuss
if release documentation will moved to the cle-documentation repo in the
future.
